### PR TITLE
remove deprecated call `bottle :unneeded`

### DIFF
--- a/git-semv.rb
+++ b/git-semv.rb
@@ -7,7 +7,6 @@ class GitSemv < Formula
   homepage "https://github.com/linyows/git-semv"
   version "1.2.0"
   license "MIT"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
It is deprecated.

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the linyows/git-semv tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/linyows/homebrew-git-semv/git-semv.rb:10
```